### PR TITLE
feat: インストール直後に初期登録を送信する機能を追加

### DIFF
--- a/data-sender/main.go
+++ b/data-sender/main.go
@@ -13,6 +13,7 @@ func main() {
 		fmt.Println("")
 		fmt.Println("Usage:")
 		fmt.Println("  data-sender process                 # Process and send current 10-minute interval")
+		fmt.Println("  data-sender register                # Send initial registration (device info + version)")
 		fmt.Println("  data-sender test                    # Test configuration and connection")
 		fmt.Println("  data-sender status                  # Show current status and configuration")
 		fmt.Println("  data-sender logs [limit]            # Show recent transmission logs (default: 10)")
@@ -22,6 +23,7 @@ func main() {
 		fmt.Println("")
 		fmt.Println("Examples:")
 		fmt.Println("  data-sender process                 # Send data for the current interval")
+		fmt.Println("  data-sender register                # Register device immediately after install")
 		fmt.Println("  data-sender test                    # Test if data transmission works")
 		fmt.Println("  data-sender logs 20                 # Show last 20 transmission attempts")
 		fmt.Println("  data-sender set-interval 5          # Set interval to 5 minutes")
@@ -41,6 +43,11 @@ func main() {
 		if err := sender.processCurrentInterval(); err != nil {
 			log.Fatalf("Error processing current interval: %v", err)
 		}
+	case "register":
+		if err := sender.SendInitialRegistration(); err != nil {
+			log.Fatalf("Error sending initial registration: %v", err)
+		}
+		fmt.Println("✅ Initial registration sent successfully!")
 	case "test":
 		sender.TestConnection()
 	case "status":

--- a/data-sender/processor.go
+++ b/data-sender/processor.go
@@ -415,3 +415,70 @@ func (ds *DataSender) saveTransmissionData(payload TransmissionPayload, startTim
 
 	return ioutil.WriteFile(filePath, data, 0644)
 }
+
+// SendInitialRegistration sends an initial registration payload with device info and version
+// This is called immediately after installation to register the device without waiting for the first interval
+func (ds *DataSender) SendInitialRegistration() error {
+	if !ds.config.Enabled {
+		log.Println("Data transmission is disabled")
+		return fmt.Errorf("data transmission is disabled")
+	}
+
+	log.Println("Sending initial registration...")
+
+	now := time.Now()
+	timestamp := now.UTC().Format(time.RFC3339)
+
+	// Create a minimal payload with device info only (no app/network data)
+	payload := TransmissionPayload{
+		DeviceID:       ds.config.DeviceID,
+		Timestamp:      timestamp,
+		IntervalMins:   0, // 0 indicates this is an initial registration, not a regular interval
+		StartTime:      timestamp,
+		EndTime:        timestamp,
+		Apps:           make([]AppData, 0),
+		Networks:       make([]NetworkData, 0),
+		SystemMetrics:  make([]SystemMetricsData, 0),
+		ProcessMetrics: make([]ProcessMetricsData, 0),
+	}
+
+	// Add metadata with device and version info
+	payload.Metadata.OSVersion = getOSVersion()
+	payload.Metadata.AgentVersion = GetAgentVersion()
+	payload.Metadata.TotalApps = 0
+	payload.Metadata.TotalDomains = 0
+
+	// Add user information
+	hostname, employeeName, employeeEmail := getUserInfo()
+	payload.Metadata.Hostname = hostname
+	payload.Metadata.EmployeeName = employeeName
+	payload.Metadata.EmployeeEmail = employeeEmail
+
+	log.Printf("Initial registration payload: DeviceID=%s, Version=%s, Hostname=%s",
+		ds.config.DeviceID, payload.Metadata.AgentVersion, hostname)
+
+	// Send data to server with retry
+	retryCount := 0
+	maxRetries := 3
+	var lastErr error
+
+	for retryCount <= maxRetries {
+		err := ds.sendData(payload)
+		if err == nil {
+			log.Printf("Initial registration sent successfully")
+			return nil
+		}
+
+		lastErr = err
+		log.Printf("Initial registration failed (attempt %d/%d): %v", retryCount+1, maxRetries+1, err)
+		retryCount++
+
+		if retryCount <= maxRetries {
+			waitTime := time.Duration(retryCount*2) * time.Second
+			log.Printf("Retrying in %v...", waitTime)
+			time.Sleep(waitTime)
+		}
+	}
+
+	return fmt.Errorf("initial registration failed after %d attempts: %v", maxRetries+1, lastErr)
+}

--- a/data-sender/utils.go
+++ b/data-sender/utils.go
@@ -251,6 +251,17 @@ ROI_AGENT_INTERVAL_MINUTES=%d
 	fmt.Println("Note: Restart the agent for the new interval to take effect.")
 }
 
+// getOSVersion retrieves the macOS version
+func getOSVersion() string {
+	// Try to get macOS version using sw_vers
+	if versionBytes, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
+		version := strings.TrimSpace(string(versionBytes))
+		return "macOS " + version
+	}
+	// Fallback
+	return "macOS"
+}
+
 // getUserInfo retrieves current user information from the system
 func getUserInfo() (hostname, employeeName, employeeEmail string) {
 	// Get hostname


### PR DESCRIPTION
- data-sender registerコマンドを追加
- SendInitialRegistration()関数でデバイス情報とバージョンを即座に送信
- getOSVersion()関数を追加してmacOSバージョンを取得
- インストール後10分待たずにDashboardに表示されるようになる